### PR TITLE
Delete .vsconfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,6 +1,0 @@
-﻿{
-  "version": "1.0",
-  "components": [
-    "Microsoft.VisualStudio.Workload.ManagedGame"
-  ]
-}


### PR DESCRIPTION
#1 
In the updated version of .gitignore, this non-essential file is blocked. Therefore it should be deleted.